### PR TITLE
typo fix prompts.py

### DIFF
--- a/4-community/agent-home/src/utils/prompts.py
+++ b/4-community/agent-home/src/utils/prompts.py
@@ -32,7 +32,7 @@ RETURN_INSTRUCTIONS:
 
 FUNCTION_PARAMETER_PROMPT = """
 You are supposed to extract the values of function parameters from user input and return them in a dictionary. 
-These extracted parameters will be used to make a fuction call later....
+These extracted parameters will be used to make a function call later....
 
 Below are the parameters and their data-type that the function takes:
 {function_parameters}


### PR DESCRIPTION
 Typo Fix in prompts.py (fuction → function)


This pull request addresses a typo in the `prompts.py` file, where "fuction" was corrected to "function."

## Changes Made

- Corrected the typo "fuction" to "function" in the `4-community/agent-home/src/utils/prompts.py` file.


