### PR TITLE
fix: update Gemini model and add missing return after error responses

### DIFF
--- a/2-solutions/google-gemini-agent/agent.py
+++ b/2-solutions/google-gemini-agent/agent.py
@@ -58,6 +58,7 @@ async def handle_request(ctx: Context, sender: str, msg: TextPrompt):
                 error="An error occurred while processing the request. Please try again later."
             ),
         )
+        return
     await ctx.send(sender, Response(text=response))
 
 
@@ -71,6 +72,7 @@ async def handle_codegen_request(ctx: Context, sender: str, msg: CodePrompt):
                 error="An error occurred while processing the request. Please try again later."
             ),
         )
+        return
     await ctx.send(sender, Response(text=response))
 
 

--- a/2-solutions/google-gemini-agent/ai.py
+++ b/2-solutions/google-gemini-agent/ai.py
@@ -3,7 +3,7 @@ import os
 import google.generativeai as genai
 
 MAX_TOKENS = int(os.getenv("MAX_TOKENS", "1024"))
-MODEL_ENGINE = os.getenv("MODEL_ENGINE", "gemini-1.5-flash")
+MODEL_ENGINE = os.getenv("MODEL_ENGINE", "gemini-3.6-flash")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "YOUR_GEMINI_API_KEY")
 if GEMINI_API_KEY is None or GEMINI_API_KEY == "YOUR_GEMINI_API_KEY":
     raise ValueError(

--- a/6-deployed-agents/knowledge-base/claude-ai-agent/agent.py
+++ b/6-deployed-agents/knowledge-base/claude-ai-agent/agent.py
@@ -71,6 +71,7 @@ async def handle_request(ctx: Context, sender: str, msg: TextPrompt):
                 error="An error occurred while processing the request. Please try again later."
             ),
         )
+        return
     await ctx.send(sender, TextResponse(text=response))
 
 
@@ -88,6 +89,7 @@ async def handle_structured_request(
                 error="An error occurred while processing the request. Please try again later."
             ),
         )
+        return
     await ctx.send(sender, StructuredOutputResponse(output=response))
 
 

--- a/6-deployed-agents/knowledge-base/google-gemini-agent/agent.py
+++ b/6-deployed-agents/knowledge-base/google-gemini-agent/agent.py
@@ -84,6 +84,7 @@ async def handle_request(ctx: Context, sender: str, msg: TextPrompt):
                 error="An error occurred while processing the request. Please try again later."
             ),
         )
+        return
     await ctx.send(sender, TextResponse(text=response))
 
 
@@ -97,6 +98,7 @@ async def handle_codegen_request(ctx: Context, sender: str, msg: CodePrompt):
                 error="An error occurred while processing the request. Please try again later."
             ),
         )
+        return
     await ctx.send(sender, CodeResponse(text=response))
 
 
@@ -114,6 +116,7 @@ async def handle_structured_request(
                 error="An error occurred while processing the request. Please try again later."
             ),
         )
+        return
     await ctx.send(sender, StructuredOutputResponse(output=json.loads(response)))
 
 

--- a/6-deployed-agents/knowledge-base/google-gemini-agent/ai.py
+++ b/6-deployed-agents/knowledge-base/google-gemini-agent/ai.py
@@ -6,7 +6,7 @@ from google import genai
 from google.genai import types
 
 MAX_TOKENS = int(os.getenv("MAX_TOKENS", "1024"))
-MODEL_ENGINE = os.getenv("MODEL_ENGINE", "gemini-2.0-flash")
+MODEL_ENGINE = os.getenv("MODEL_ENGINE", "gemini-3.6-flash")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "YOUR_GEMINI_API_KEY")
 if GEMINI_API_KEY is None or GEMINI_API_KEY == "YOUR_GEMINI_API_KEY":
     raise ValueError(


### PR DESCRIPTION
- Update default MODEL_ENGINE from deprecated gemini-2.0-flash (and gemini-1.5-flash in the tutorial copy) to gemini-3.6-flash as required by the Google Gemini API
- Add missing `return` statements after sending ErrorMessage in message handlers across the Gemini and Claude.ai agents, preventing a second response being sent on the error path